### PR TITLE
增加交互性，为每个统计图的子元素添加跳转

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hexo-graph
 
-> hexo-graph，一个基于 echarts，集成博客热力图，博客月份统计图，分类统计图，标签统计图的多元化插件。
+> hexo-graph，一个基于 echarts，集成博客热力图，博客月份统计图，分类统计图，标签统计图的多元化可交互插件。
 
 具体效果：https://haohanxinghe.com/social/stats/
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -3,6 +3,8 @@ const moment = require('moment');
 function generateStats(hexo) {
     const posts = hexo.locals.get('posts');
 
+    
+
     // 初始化统计对象
     const monthlyCount = {};
     const dailyCount = {}; // 按天统计
@@ -105,6 +107,17 @@ function generateHeatmapChart(sortedDailyCount) {
                         data: ${data}
                     }]
                 });
+                 // 虽然一天可能有多篇文章，但hexo的archives只精确到月份，所以这里只跳转到月份页面
+                heatmapChart.on('click', function(params) {
+                       if (params.componentType === 'series') {
+                        const dateStr = params.value[0];
+                        const dateParts = dateStr.split('-');
+                        const year = parseInt(dateParts[0], 10);
+                        const month = parseInt(dateParts[1], 10);
+                        const formattedMonth = \`\${year}/\${String(month).padStart(2, '0')}\`;
+                        window.location.href = '/archives/' + formattedMonth; // 一般归档页面路径为/archives/YYYY-MM
+                    }
+                });
             }
         </script>
     `;
@@ -138,6 +151,14 @@ function generateMonthlyChart(sortedMonthlyCount) {
                         animationDuration: 1000
                     }]
                 });
+                //同上，跳转到月份页面 param对象还不一样。我排错半天：（
+                 monthlyChart.on('click', function(params) {
+                    if (params.componentType === 'series') {
+                        const year = params.name.split('-')[0];
+                        const month = params.name.split('-')[1];
+                        window.location.href = '/archives/' + year + '/' + month; 
+                    }
+                });
             }
         </script>
     `;
@@ -168,6 +189,12 @@ function generateTagsChart(topTags) {
                         left: 'center',
                         data: ${tags}.map(tag => tag.name),
                         textStyle: { fontSize: 12 }
+                    }
+                });
+                tagsChart.on('click', function(params) {
+                    if (params.componentType === 'series') {
+                        const tag = params.name;
+                        window.location.href = '/tags/' + tag;
                     }
                 });
             }
@@ -208,6 +235,12 @@ function generateCategoriesChart(topCategories) {
                         },
                         animationDuration: 1000
                     }]
+                });
+                categoriesChart.on('click', function(params) {
+                    if (params.componentType === 'series') {
+                        const category = params.name;
+                        window.location.href = '/categories/' + category;
+                    }
                 });
             }
         </script>

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -148,6 +148,7 @@ function generateMonthlyChart(sortedMonthlyCount) {
                         lineStyle: { color: '#5470C6', width: 2 },
                         itemStyle: { color: '#5470C6' },
                         areaStyle: { color: 'rgba(84, 112, 198, 0.4)' },
+                        symbolSize: 10, //圆点大一点，方便点击
                         animationDuration: 1000
                     }]
                 });


### PR DESCRIPTION
考虑到hexo的archives最多精确到月份，故

在热力图中，点击图块跳转到月份，在月份统计图中也是如此
`/archives/YYYY/MM`
在标签统计图中，点击对应标签跳转到
`/tags/the_tag`
在分类统计图中，点击对应分类跳转到
`/categories/the_category`
