### PR TITLE
feat: navigation buttons to switch heatmap between years

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ hexo_graph:
 ></div>
 ```
 
+**Heatmap年份切换**
+当鼠标悬停在 heatmap 图标左侧或者右侧的时候，会显示向后或者向前的箭头，点击箭头可以切换到上一年或者下一年的数据
 
 ![image-20241231223115464](https://image.codepzj.cn/image/202412312231916.png)
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ hexo_graph:
     - "#F9B5E2" # 浅桃粉色
 ```
 
+**Heatmap年份配置**
+可以在 html 标签中添加`year`属性，来指定年份，不填默认为当前年份
+
+```html
+### Blog Heatmap
+
+<div
+  id="heatmapChart"
+  year="2024"
+  style="width: 100%; height: 200px; overflow-x: auto; overflow-y: hidden; border-radius: 10px; padding: 10px;box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);"
+></div>
+```
+
+
 ![image-20241231223115464](https://image.codepzj.cn/image/202412312231916.png)
 
 ![image-20241231223150999](https://image.codepzj.cn/image/202412312231480.png)

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -54,11 +54,12 @@ function generateHeatmapChart(sortedDailyCount, darkMode, colors) {
             const heatmapChart = echarts.init(document.getElementById('heatmapChart'), '${darkMode}');
             const containerWidth = document.getElementById('heatmapChart').offsetWidth;
             const cellSize = Math.max(Math.floor(containerWidth / 58), 10);
+            var year = document.getElementById('heatmapChart').getAttribute('year') || new Date().getFullYear();
 
             heatmapChart.setOption({
                 tooltip: { position: 'top', formatter: params => \`\${params.value[0]}: \${params.value[1]} Articles\` },
                 calendar: { 
-                    top: '20%', left: 'center', range: new Date().getFullYear(), cellSize, 
+                    top: '20%', left: 'center', range: year, cellSize, 
                     splitLine: { lineStyle: { color: '#E0E0E0', width: 1 } }, 
                     itemStyle: { borderWidth: 1, borderColor: '#E0E0E0' }, 
                     dayLabel: { show: false }, 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -54,7 +54,20 @@ function generateHeatmapChart(sortedDailyCount, darkMode, colors) {
             const heatmapChart = echarts.init(document.getElementById('heatmapChart'), '${darkMode}');
             const containerWidth = document.getElementById('heatmapChart').offsetWidth;
             const cellSize = Math.max(Math.floor(containerWidth / 58), 10);
-            var year = document.getElementById('heatmapChart').getAttribute('year') || new Date().getFullYear();
+            var year = parseInt(document.getElementById('heatmapChart').getAttribute('year')) || new Date().getFullYear();
+
+            function updateHeatmap(newYear) {
+                year = newYear;
+                heatmapChart.setOption({
+                    calendar: {
+                        range: year,
+                        cellSize,
+                    },
+                    series: [{
+                        data: ${data}.filter(item => item[0].startsWith(String(year)))
+                    }]
+                });
+            }
 
             heatmapChart.setOption({
                 tooltip: { position: 'top', formatter: params => \`\${params.value[0]}: \${params.value[1]} Articles\` },
@@ -69,7 +82,7 @@ function generateHeatmapChart(sortedDailyCount, darkMode, colors) {
                 series: [{
                     type: 'heatmap',
                     coordinateSystem: 'calendar',
-                    data: ${data},
+                    data: ${data}.filter(item => item[0].startsWith(String(year))),
                 }]
             });
 
@@ -78,6 +91,60 @@ function generateHeatmapChart(sortedDailyCount, darkMode, colors) {
                     const [year, month] = params.value[0].split('-');
                     window.location.href = '/archives/' + year + '/' + month;
                 }
+            });
+
+            const heatmapContainer = document.getElementById('heatmapChart');
+            const buttonLeft = document.createElement('button');
+            const buttonRight = document.createElement('button');
+
+            // set button style
+            buttonLeft.innerText = '<';
+            buttonRight.innerText = '>';
+            buttonLeft.style.left = '5px';
+            buttonRight.style.right = '5px';
+            buttonLeft.style.position = buttonRight.style.position = 'absolute';
+            buttonLeft.style.top = buttonRight.style.top = '50%';
+            buttonLeft.style.transform = buttonRight.style.transform = 'translateY(-50%)';
+            buttonLeft.style.fontSize = buttonRight.style.fontSize = '24px';
+            buttonLeft.style.cursor = buttonRight.style.cursor = 'pointer';
+            buttonLeft.style.display = buttonRight.style.display = 'none';
+            buttonLeft.style.background = buttonRight.style.background = 'none';
+            buttonLeft.style.border = buttonRight.style.border = 'none';
+            buttonLeft.style.padding = buttonRight.style.padding = '0';
+            
+            heatmapContainer.style.position = 'relative';
+            heatmapContainer.appendChild(buttonLeft);
+            heatmapContainer.appendChild(buttonRight);
+
+            buttonLeft.addEventListener('click', function () {
+                updateHeatmap(year - 1);
+            });
+
+            buttonRight.addEventListener('click', function () {
+                updateHeatmap(year + 1);
+            });
+
+            heatmapContainer.addEventListener('mousemove', function (e) {
+                const rect = heatmapContainer.getBoundingClientRect();
+                const buttonWidth = 30;
+
+                // check mouse position
+                if (e.clientX - rect.left < buttonWidth + 10) { // 10px is extra click area
+                    buttonLeft.style.display = 'block';
+                } else {
+                    buttonLeft.style.display = 'none';
+                }
+
+                if (rect.right - e.clientX < buttonWidth + 10) { // 10px is extra click area
+                    buttonRight.style.display = 'block';
+                } else {
+                    buttonRight.style.display = 'none';
+                }
+            });
+
+            heatmapContainer.addEventListener('mouseleave', function () {
+                buttonLeft.style.display = 'none';
+                buttonRight.style.display = 'none';
             });
         </script>
     `;


### PR DESCRIPTION
当鼠标悬停在 heatmap 图标左侧或者右侧的时候，会显示向后或者向前的箭头，点击箭头可以切换到上一年或者下一年的数据。
我对JS和CSS不是很熟悉，按钮的风格和鼠标监听范围有待优化。